### PR TITLE
Fix: set length constraint on user profile's zipcode column

### DIFF
--- a/backend/app/models/user_profile_model.py
+++ b/backend/app/models/user_profile_model.py
@@ -14,6 +14,6 @@ class UserProfile(Base):
     address2 = Column(String, nullable=True)
     city = Column(String)
     state = Column(String)
-    zipcode = Column(String)
+    zipcode = Column(String(5))
 
     #user = relationship("User", back_populates="users")


### PR DESCRIPTION
Doesn't seem to have any practical effect. Maybe this is an SQLite thing?